### PR TITLE
fixed header still being None and added a permissionerror check

### DIFF
--- a/resubmit.py
+++ b/resubmit.py
@@ -42,6 +42,9 @@ if options.rl_file != None:
         print("Could not build header from provided run_list file. Using default.")
         header = default_header
 
+if not header:
+    header = default_header
+
 if options.cpr == 1:
     header += "set cpr 1\n"
 
@@ -103,7 +106,15 @@ for run in run_logs:
                 continue
         
             if os.path.exists(rep+"/checkpoint_safe.blcr") and options.cpr:
-                shutil.copy(rep+"/checkpoint_safe.blcr", rep+"/checkpoint.blcr")
+                try:
+                    shutil.copy(rep+"/checkpoint_safe.blcr", rep+"/checkpoint.blcr")
+                except IOError: 
+                    '''Note: Technically we should check if e.errno==EACCES
+                    or switch to py3 to use PermissionError'''
+                    print "Not resubmitting", rep, "because don't have permission."
+                    not_resubmitted.append(rep)
+                    continue
+                    
             elif options.cpr:
                 print "Not resubmitting", rep, "because there's no checkpoint."
                 not_resubmitted.append(rep)


### PR DESCRIPTION
I was running into an error where the header was None still, so I just put in a check and gave it the default header. Due to the weirdness of permissions in our research folder, I was also running into a lot of errors because resubmit couldn't open the file, so I put in a catch for that. The catch should check more to make sure it is a permissions error, but that requires more importing, so up to you whether you think we should or not. Python3 has a PermissionError in the built-in if you were thinking of converting ever.
