### PR TITLE
Exempt escaped pound signs as comment delimiters

### DIFF
--- a/dist_qsub.py
+++ b/dist_qsub.py
@@ -62,7 +62,7 @@ settings = {}
 processes = []
 for line in fd:
 
-    if line.find('#') > -1 and line[max(0,line.find('#')-1)] != '\':
+    if line.find('#') > -1 and line[max(0,line.find('#')-1)] != '\\':
         line = line[:line.find('#')]
 
     line = line.strip().lstrip() ## strip off the leading and following whitespace.

--- a/dist_qsub.py
+++ b/dist_qsub.py
@@ -62,7 +62,7 @@ settings = {}
 processes = []
 for line in fd:
 
-    if line.find('#') > -1:
+    if line.find('#') > -1 and line[max(0,line.find('#')-1)] != '\':
         line = line[:line.find('#')]
 
     line = line.strip().lstrip() ## strip off the leading and following whitespace.


### PR DESCRIPTION
Allow pound literals if you put a backslash in front of them!